### PR TITLE
Make simulation faster 

### DIFF
--- a/glaze2.py
+++ b/glaze2.py
@@ -85,7 +85,7 @@ def prior(b_prior, H):
     return psi
 
 
-def belief(df, H, e1=0.5, e2=-0.5, sigma=1):
+def belief(df, H):
     '''
     Returns models Belief at a given time.
 
@@ -114,9 +114,9 @@ def cross_entropy_error(df, H):
 
     # Find last point location before choice trial
     belief_indices = df.loc[choices.index - 12].index.values
-    pnm = belief(df, H).loc[belief_indices].values
+    pnm = -belief(df, H).loc[belief_indices].values
     pnm = expit(pnm)
-    pn = -choices.values + 1
+    pn = choices.values
     return -np.sum(((1 - pn) * np.log(1 - pnm)) + (pn * np.log(pnm)))
 
 

--- a/pointsimulation.py
+++ b/pointsimulation.py
@@ -7,7 +7,7 @@ import matplotlib.pyplot as plt
 import random
 from scipy import optimize as opt
 from scipy.special import expit  # logistic function
-
+from scipy.stats import expon, norm
 
 # SIMULATE POINT LOCATIONS AND DECISION POINTS
 
@@ -83,6 +83,32 @@ def simulate(x, tH=1 / 70):
     return df
 
 # FILL IN MISSING INFORMATION
+
+
+def fast_sim(x, tH=1 / 70):
+    inter_change_dists = expon.rvs(scale=1 / (1 / 70), size=1000)
+    inter_choice_dists = np.cumsum(expon.rvs(scale=1 / (1 / 35), size=1000))
+    inter_choice_dists = inter_choice_dists[inter_choice_dists < x]
+    mus = []
+    values = []
+    start = random.choice([0.5, -0.5])
+    cnt = 0
+    for i in inter_change_dists:
+        mus.append([start] * int(i))
+        values.append(norm.rvs(start, 1, size=int(i)))
+        start *= -1
+        if cnt > x:
+            break
+        cnt += i
+
+    df = pd.DataFrame({'rule': np.concatenate(mus)[:x], 'value': np.concatenate(
+        values)[:x]})
+
+    #df.columns = ['rule', 'values']
+    df.loc[:, 'message'] = 'GL_TRIAL_LOCATION'
+    df.loc[inter_choice_dists.astype(int), 'message'] = 'decision'
+    df.loc[:, 'index'] = np.arange(len(df))
+    return df
 
 
 def add_belief(df, H):
@@ -185,4 +211,3 @@ added function to compute cross entropy error
 added function to calculate optimal model hazardrate
 made actual generating hazardrate optional parameter in simulate
 '''
-


### PR DESCRIPTION
fast_sim does not append to a data frame, which makes it faster. It also vectorizes more by directly sampling inter change durations and inter choice durations from an exponential distribution.